### PR TITLE
Change 'matrix' according to mentor feedback

### DIFF
--- a/matrix/honorable_mentions/immutable_matrix.py
+++ b/matrix/honorable_mentions/immutable_matrix.py
@@ -1,0 +1,21 @@
+from typing import List, Tuple
+
+# From mentor:
+# Fun fact. If someone does: matrix.row(3)[0] = 5, this will alter the data stored in the matrix.
+# Conversely, if they did matrix.column(3)[0] = 5, this would not update the matrix.
+# Making row() behave like column() is simple.
+# The reverse is a fair bit more tricky. Something to think about :)
+
+
+class Matrix:
+
+    __matrix: Tuple[Tuple[int]]
+
+    def __init__(self, matrix_string: str):
+        self.__matrix = tuple([tuple([int(x) for x in row.split()]) for row in matrix_string.splitlines()])
+
+    def row(self, index: int) -> List[int]:
+        return list(self.__matrix[index - 1])
+
+    def column(self, index: int) -> List[int]:
+        return [row[index - 1] for row in self.__matrix]

--- a/matrix/matrix.py
+++ b/matrix/matrix.py
@@ -5,7 +5,7 @@ class Matrix:
     __matrix: List[List[int]]
 
     def __init__(self, matrix_string: str):
-        self.__matrix = [list(map(int, row.split(' '))) for row in matrix_string.splitlines()]
+        self.__matrix = [[int(x) for x in row.split()] for row in matrix_string.splitlines()]
 
     def row(self, index: int) -> List[int]:
         return self.__matrix[index - 1]


### PR DESCRIPTION
This commit deals with changes according to the mentor feedback:

> Do you need to specify a separator for your per-line str.split call?

No I do not need to specify a separator, because according to the docs whitespace is the default separator.

> This solution combines functions that act on lists (list(map(..)))
> with list comprehensions. Could you solve this with the consistent use
> of just list comprehensions?

Yes this is is also possible. Changed the code accordingly.
